### PR TITLE
fix(ci): stop selecting bundler 2.1.0 on Pages build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,4 +96,4 @@ DEPENDENCIES
   jekyll-redirect-from (~> 0.16.0)
 
 BUNDLED WITH
-   2.1.0
+   2.4.20


### PR DESCRIPTION
## Summary
The Pages build on `master` is currently failing in Bundler before Jekyll starts.

This lockfile still says `BUNDLED WITH 2.1.0`, so CI installs that ancient Bundler on Ruby 3.3 and dies with `SystemStackError: stack level too deep` (see run `23646185373`).

This updates the lockfile to the Bundler version that works locally and is compatible with the current Ruby/Jekyll setup.

## Verification
- `bundle install`
- `make build`

That completed successfully locally after this change.
